### PR TITLE
Replace minifyCss with cssnano (minifyCss is deprecated)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Elixir.extend('uncss', function(styles, options, output, baseDir) {
 
         return gulp.src(paths.src.path)
             .pipe(uncss(options || {}))
-            .pipe($.if(config.production, $.minifyCss()))
+            .pipe($.if(config.production, $.cssnano()))
             .pipe(gulp.dest(paths.output.baseDir));
     });
 });


### PR DESCRIPTION
"gulp-minify-css" plugin was replaced in Elixir 4.2 with cssnano: https://github.com/laravel/elixir

There is no minifyCss in Elixir.Plugins anymore, so it simply doesn't work with Elixir 4.2.
